### PR TITLE
fix: update arc-testnet service name

### DIFF
--- a/networks.json
+++ b/networks.json
@@ -1,5 +1,5 @@
 [
-    {
+  {
     "name": "genlayer",
     "type": "testnet",
     "title": "GenLayer",
@@ -10,16 +10,20 @@
     "icon": "https://raw.githubusercontent.com/Validator-POSTHUMAN/posthuman-source-data/refs/heads/main/genlayer/genlayer-logo.svg",
     "stake": "",
     "explorer": "",
-	"chain_id": "asimov-phase5",
+    "chain_id": "asimov-phase5",
     "endpoints": {
-		"rpc": "https://rpc.genlayer.posthuman.digital:443",
-		"snapshots": "https://snapshots.genlayer.posthuman.digital:443"
-	},
+      "rpc": "https://rpc.genlayer.posthuman.digital:443",
+      "snapshots": "https://snapshots.genlayer.posthuman.digital:443"
+    },
     "contributions": "Genlayer",
     "generatedServices": [],
-    "services": ["install-guide","troubleshooting","useful-commands"]
+    "services": [
+      "install-guide",
+      "troubleshooting",
+      "useful-commands"
+    ]
   },
- {
+  {
     "name": "firmachain",
     "type": "mainnet",
     "title": "FirmaChain",
@@ -27,17 +31,19 @@
     "twitter": "https://x.com/FirmaChain",
     "github": "https://github.com/FirmaChain/",
     "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/refs/heads/master/firmachain/images/fct.svg",
-	"stake": "",
+    "stake": "",
     "explorer": "",
-	"daemon_name": "firmachaind",
+    "daemon_name": "firmachaind",
     "codebase": {
-	  "git_repo": "https://github.com/firmachain/firmachain",
+      "git_repo": "https://github.com/firmachain/firmachain",
       "recommended_version": "v0.5.1-patch2",
-      "compatible_versions": ["v0.5.1-patch2"]
-	  },	
+      "compatible_versions": [
+        "v0.5.1-patch2"
+      ]
+    },
     "chain_id": "colosseum-1",
-	"genesis_ulr": "https://snapshots.firmachain.posthuman.digital/genesis.json",
-	"addrbookUrl": "https://snapshots.firmachain.posthuman.digital/addrbook.json",
+    "genesis_ulr": "https://snapshots.firmachain.posthuman.digital/genesis.json",
+    "addrbookUrl": "https://snapshots.firmachain.posthuman.digital/addrbook.json",
     "endpoints": {
       "rpc": "https://rpc.firmachain.posthuman.digital:443",
       "rest": "https://rest.firmachain.posthuman.digital:443",
@@ -45,11 +51,16 @@
       "peer": "3168796330fb85ab21f797f0e2df84e7a98e1983@peer.firmachain.posthuman.digital:49656",
       "snapshots": "https://snapshots.firmachain.posthuman.digital:443"
     },
-	"contributions": "FirmaChain",
-    "generatedServices": ["installation-guide", "state-sync"],
-    "services": ["snapshots"]
+    "contributions": "FirmaChain",
+    "generatedServices": [
+      "installation-guide",
+      "state-sync"
+    ],
+    "services": [
+      "snapshots"
+    ]
   },
- {
+  {
     "name": "fetchhub",
     "type": "mainnet",
     "title": "Fetch.ai",
@@ -57,17 +68,19 @@
     "twitter": "https://x.com/Fetch_ai",
     "github": "https://github.com/fetchai/",
     "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/refs/heads/master/fetchhub/images/fet_white.svg",
-	"stake": "",
+    "stake": "",
     "explorer": "",
-	"daemon_name": "fetchd",
+    "daemon_name": "fetchd",
     "codebase": {
-	  "git_repo": "https://github.com/fetchai/fetchd",
+      "git_repo": "https://github.com/fetchai/fetchd",
       "recommended_version": "v0.14.1",
-      "compatible_versions": ["v0.14.1"]
-	  },	
+      "compatible_versions": [
+        "v0.14.1"
+      ]
+    },
     "chain_id": "fetchhub-4",
-	"genesis_ulr": "https://snapshots.fetch.posthuman.digital/genesis.json",
-	"addrbookUrl": "https://snapshots.fetch.posthuman.digital/addrbook.json",
+    "genesis_ulr": "https://snapshots.fetch.posthuman.digital/genesis.json",
+    "addrbookUrl": "https://snapshots.fetch.posthuman.digital/addrbook.json",
     "endpoints": {
       "rpc": "https://rpc.fetch.posthuman.digital:443",
       "rest": "https://rest.fetch.posthuman.digital:443",
@@ -75,9 +88,14 @@
       "peer": "0584f51f43be88dec1f9790b1321975af2e6606c@peer.fetch.posthuman.digital:43656",
       "snapshots": "https://snapshots.fetch.posthuman.digital:443"
     },
-	"contributions": "FetchAI",
-    "generatedServices": ["installation-guide", "state-sync"],
-    "services": ["snapshots"]
+    "contributions": "FetchAI",
+    "generatedServices": [
+      "installation-guide",
+      "state-sync"
+    ],
+    "services": [
+      "snapshots"
+    ]
   },
   {
     "name": "axelar",
@@ -99,8 +117,13 @@
       "snapshots": "https://snapshots.axelar.posthuman.digital:443"
     },
     "contributions": "Axelar",
-    "generatedServices": ["installation-guide", "state-sync"],
-    "services": ["snapshots"]
+    "generatedServices": [
+      "installation-guide",
+      "state-sync"
+    ],
+    "services": [
+      "snapshots"
+    ]
   },
   {
     "name": "pchain",
@@ -113,27 +136,34 @@
     "icon": "https://raw.githubusercontent.com/Validator-POSTHUMAN/posthuman-source-data/refs/heads/main/push/push-logo.svg",
     "stake": "",
     "explorer": "",
-	"daemon_name": "pchaind",
-	"node_name": "NodeName",
+    "daemon_name": "pchaind",
+    "node_name": "NodeName",
     "codebase": {
-	  "git_repo": "https://github.com/pushchain/push-chain-node.git",
+      "git_repo": "https://github.com/pushchain/push-chain-node.git",
       "recommended_version": "v0.0.18",
-      "compatible_versions": ["v0.0.18"]
-    },	
+      "compatible_versions": [
+        "v0.0.18"
+      ]
+    },
     "chain_id": "push_42101-1",
-	"genesis_url": "https://snapshots.push.posthuman.digital/genesis.json",
-	"addrbookUrl": "https://snapshots.push.posthuman.digital/addrbook.json",
+    "genesis_url": "https://snapshots.push.posthuman.digital/genesis.json",
+    "addrbookUrl": "https://snapshots.push.posthuman.digital/addrbook.json",
     "endpoints": {
       "rpc": "https://rpc.push.posthuman.digital:443",
       "rest": "https://rest.push.posthuman.digital:443",
       "grpc": "https://grpc.push.posthuman.digital:443",
-	  "json-rpc": "https://json-rpc.push.posthuman.digital:443",
+      "json-rpc": "https://json-rpc.push.posthuman.digital:443",
       "peer": "7bf1c608994f3f0b6b65aa52072d164c9d8a7f4d@peer.push.posthuman.digital:50656",
       "snapshots": "https://snapshots.push.posthuman.digital:443"
     },
-	"contributions": "PushChain",
-    "generatedServices": ["installation-guide", "state-sync"],
-    "services": ["snapshots"]
+    "contributions": "PushChain",
+    "generatedServices": [
+      "installation-guide",
+      "state-sync"
+    ],
+    "services": [
+      "snapshots"
+    ]
   },
   {
     "name": "gno",
@@ -144,9 +174,11 @@
     "endpoints": {
       "rpc": "https://rpc.gno.posthuman.digital:443"
     },
-	"contributions": "Gno-land",
+    "contributions": "Gno-land",
     "generatedServices": [],
-    "services": ["installation-guide"]
+    "services": [
+      "installation-guide"
+    ]
   },
   {
     "name": "provenance",
@@ -167,9 +199,14 @@
       "peer": "7bf1c608994f3f0b6b65aa52072d164c9d8a7f4d@peer.provenance.posthuman.digital:44656",
       "snapshots": "https://snapshots.provenance.posthuman.digital:443"
     },
-	"contributions": "Provenance",
-    "generatedServices": ["installation-guide", "state-sync"],
-    "services": ["snapshots"]
+    "contributions": "Provenance",
+    "generatedServices": [
+      "installation-guide",
+      "state-sync"
+    ],
+    "services": [
+      "snapshots"
+    ]
   },
   {
     "name": "shentu",
@@ -190,9 +227,14 @@
       "peer": "77f21eee88ff4f895ff79dbdabb3e726c3f5eba5@peer.shentu.posthuman.digital:50656",
       "snapshots": "https://snapshots.shentu.posthuman.digital:443"
     },
-	"contributions": "",
-    "generatedServices": ["installation-guide", "state-sync"],
-    "services": ["snapshots"]
+    "contributions": "",
+    "generatedServices": [
+      "installation-guide",
+      "state-sync"
+    ],
+    "services": [
+      "snapshots"
+    ]
   },
   {
     "name": "lumen",
@@ -207,9 +249,13 @@
     "endpoints": {
       "rpc": ""
     },
-	"contributions": "",
+    "contributions": "",
     "generatedServices": [],
-    "services": ["validators", "blockchain", "validator-kit"]
+    "services": [
+      "validators",
+      "blockchain",
+      "validator-kit"
+    ]
   },
   {
     "name": "starknet",
@@ -226,7 +272,10 @@
     },
     "contributions": "Starknet",
     "generatedServices": [],
-    "services": ["installation-guide", "validator-attestation"]
+    "services": [
+      "installation-guide",
+      "validator-attestation"
+    ]
   },
   {
     "name": "ethereum",
@@ -242,7 +291,9 @@
       "jsonrpc": ""
     },
     "generatedServices": [],
-    "services": ["install-guide"]
+    "services": [
+      "install-guide"
+    ]
   },
   {
     "name": "cosmoshub",
@@ -263,8 +314,15 @@
       "seed-node": "6d581e53245f7f81c24a20392b60256a7e59de59@peer.cosmos.posthuman.digital:26656"
     },
     "contributions": "Cosmos",
-    "generatedServices": ["state-sync", "peers"],
-    "services": ["install-guide", "ibc-relayers", "links"]
+    "generatedServices": [
+      "state-sync",
+      "peers"
+    ],
+    "services": [
+      "install-guide",
+      "ibc-relayers",
+      "links"
+    ]
   },
   {
     "name": "dymension",
@@ -284,7 +342,11 @@
       "seed-node": "7f5862bc6b2a13fee3a1928c2c7aed33edb711a2@peer.dymension.posthuman.digital:25656"
     },
     "contributions": "Dymension",
-    "generatedServices": ["installation-guide", "state-sync", "peers"],
+    "generatedServices": [
+      "installation-guide",
+      "state-sync",
+      "peers"
+    ],
     "services": []
   },
   {
@@ -302,7 +364,11 @@
       "seed-node": "7f5862bc6b2a13fee3a1928c2c7aed33edb711a2@peer.humans.posthuman.digital:27656"
     },
     "contributions": "Humans_ai",
-    "generatedServices": ["installation-guide", "state-sync", "peers"],
+    "generatedServices": [
+      "installation-guide",
+      "state-sync",
+      "peers"
+    ],
     "services": [],
     "images": [
       {
@@ -325,8 +391,12 @@
       "seed-node": "9aa69d667da6dd43ba82110b4ff290ac38d68976@135.181.227.236:60656"
     },
     "contributions": "Atomone",
-    "generatedServices": ["installation-guide"],
-    "services": ["snapshot-service"]
+    "generatedServices": [
+      "installation-guide"
+    ],
+    "services": [
+      "snapshot-service"
+    ]
   },
   {
     "name": "atomone",
@@ -343,8 +413,17 @@
       "seed-node": "494f6198020d91571f75b4f208b739e2da50578e@135.181.227.236:63656"
     },
     "contributions": "Atomone",
-    "generatedServices": ["installation-guide", "state-sync", "peers"],
-    "services": ["IBC-Relayers", "genesis-and-addrbook", "snapshot-service", "one-liner"]
+    "generatedServices": [
+      "installation-guide",
+      "state-sync",
+      "peers"
+    ],
+    "services": [
+      "IBC-Relayers",
+      "genesis-and-addrbook",
+      "snapshot-service",
+      "one-liner"
+    ]
   },
   {
     "name": "stargaze",
@@ -360,7 +439,11 @@
       "seed-node": "ea4ac95dd628844361cdee9b33e4c5db085d70e7@peer.stargaze.posthuman.digital:32656"
     },
     "contributions": "Stargaze",
-    "generatedServices": ["installation-guide", "state-sync", "peers"],
+    "generatedServices": [
+      "installation-guide",
+      "state-sync",
+      "peers"
+    ],
     "services": []
   },
   {
@@ -378,7 +461,9 @@
     },
     "chain_id": "ethereum",
     "generatedServices": [],
-    "services": ["installation-guide"]
+    "services": [
+      "installation-guide"
+    ]
   },
   {
     "name": "namada",
@@ -395,7 +480,12 @@
     },
     "contributions": "Namada",
     "generatedServices": [],
-    "services": ["installation-guide", "genesis-file", "addr-book", "snapshot-service"]
+    "services": [
+      "installation-guide",
+      "genesis-file",
+      "addr-book",
+      "snapshot-service"
+    ]
   },
   {
     "name": "celestia",
@@ -411,7 +501,9 @@
     "codebase": {
       "git_repo": "https://github.com/celestiaorg/celestia-app",
       "recommended_version": "v5.0.11",
-      "compatible_versions": ["v5.0.11"]
+      "compatible_versions": [
+        "v5.0.11"
+      ]
     },
     "chain_id": "celestia",
     "endpoints": {
@@ -442,7 +534,9 @@
     "codebase": {
       "git_repo": "https://github.com/celestiaorg/celestia-app",
       "recommended_version": "v6.2.0-mocha",
-      "compatible_versions": ["v6.2.0-mocha"]
+      "compatible_versions": [
+        "v6.2.0-mocha"
+      ]
     },
     "chain_name": "celestia-app",
     "title": "Celestia",
@@ -490,7 +584,10 @@
       "peer": "a31df340e2a186a0541cdb5099a1cca6eab67c75@135.181.61.154:12756"
     },
     "contributions": "Agoric",
-    "generatedServices": ["state-sync", "peers"],
+    "generatedServices": [
+      "state-sync",
+      "peers"
+    ],
     "services": [
       "installation-guide",
       "IBC-Relayers",
@@ -522,8 +619,14 @@
       "peer": "4ba715e890aeceb9fef100c7c404004d1d711f37@46.4.52.158:656"
     },
     "contributions": "Warden",
-    "generatedServices": ["installation-guide", "state-sync"],
-    "services": ["oracle-slinky-setup-guide", "snapshots"]
+    "generatedServices": [
+      "installation-guide",
+      "state-sync"
+    ],
+    "services": [
+      "oracle-slinky-setup-guide",
+      "snapshots"
+    ]
   },
   {
     "name": "kyve",
@@ -543,8 +646,13 @@
       "peer": "b9d43e8179f17410abce8279a750d4945d8524c7@135.181.227.236:33656"
     },
     "contributions": "Kyve",
-    "generatedServices": ["installation-guide", "state-sync"],
-    "services": ["snapshots"]
+    "generatedServices": [
+      "installation-guide",
+      "state-sync"
+    ],
+    "services": [
+      "snapshots"
+    ]
   },
   {
     "name": "oraichain",
@@ -564,8 +672,13 @@
       "peer": "07dde93a5ea10fc4623ef421d0de0e2b5b556e80@135.181.227.236:55656"
     },
     "contributions": "Orai",
-    "generatedServices": ["installation-guide", "state-sync"],
-    "services": ["snapshots"]
+    "generatedServices": [
+      "installation-guide",
+      "state-sync"
+    ],
+    "services": [
+      "snapshots"
+    ]
   },
   {
     "name": "zetachain",
@@ -588,8 +701,13 @@
       "peer": "21cc2d900409df3612d4b00537c9ebaf09fab2f6@135.181.227.236:31656"
     },
     "contributions": "Zetachain",
-    "generatedServices": ["installation-guide", "state-sync"],
-    "services": ["snapshots"]
+    "generatedServices": [
+      "installation-guide",
+      "state-sync"
+    ],
+    "services": [
+      "snapshots"
+    ]
   },
   {
     "name": "juno-testnet",
@@ -609,8 +727,13 @@
       "peer": "ea35c818280a6ac5d1d2a987d8d60f4bd76f4e06@141.95.34.193:16656"
     },
     "contributions": "JunoNetwork",
-    "generatedServices": ["installation-guide", "state-sync"],
-    "services": ["snapshots"]
+    "generatedServices": [
+      "installation-guide",
+      "state-sync"
+    ],
+    "services": [
+      "snapshots"
+    ]
   },
   {
     "name": "juno",
@@ -630,8 +753,13 @@
       "peer": "113a11ad866cddddea40ddf9b56fde43f03d7499@135.181.227.236:12656"
     },
     "contributions": "JunoNetwork",
-    "generatedServices": ["installation-guide", "state-sync"],
-    "services": ["snapshots"]
+    "generatedServices": [
+      "installation-guide",
+      "state-sync"
+    ],
+    "services": [
+      "snapshots"
+    ]
   },
   {
     "name": "exrp-testnet",
@@ -652,8 +780,13 @@
       "peer": "e80a91daedb88e1dc429ab60036b3819bb48057d@peer.exrp.posthuman.digital:62656"
     },
     "contributions": "XRPL",
-    "generatedServices": ["installation-guide", "state-sync"],
-    "services": ["snapshots"]
+    "generatedServices": [
+      "installation-guide",
+      "state-sync"
+    ],
+    "services": [
+      "snapshots"
+    ]
   },
   {
     "name": "exrp",
@@ -674,8 +807,13 @@
       "peer": "522e624a77123c67762b5c1ff70ac20d377b0179@peer.exrp.posthuman.digital:61656"
     },
     "contributions": "XRPL",
-    "generatedServices": ["installation-guide", "state-sync"],
-    "services": ["snapshots"]
+    "generatedServices": [
+      "installation-guide",
+      "state-sync"
+    ],
+    "services": [
+      "snapshots"
+    ]
   },
   {
     "name": "fuel",
@@ -695,8 +833,12 @@
       "peer": "59047d7c1202593de3f4a71c767276094700d38c@peer.fuel.posthuman.digital:10656"
     },
     "contributions": "Fuel",
-    "generatedServices": ["installation-guide"],
-    "services": ["snapshots"]
+    "generatedServices": [
+      "installation-guide"
+    ],
+    "services": [
+      "snapshots"
+    ]
   },
   {
     "name": "neutron",
@@ -716,8 +858,13 @@
       "peer": "d5ce5e05dad8d5ed75709e2e4c591e088ade8dd5@peer.neutron.posthuman.digital:13656"
     },
     "contributions": "Neutron",
-    "generatedServices": ["installation-guide", "state-sync"],
-    "services": ["snapshots"]
+    "generatedServices": [
+      "installation-guide",
+      "state-sync"
+    ],
+    "services": [
+      "snapshots"
+    ]
   },
   {
     "name": "babylon-testnet",
@@ -739,7 +886,12 @@
     },
     "contributions": "Babylon",
     "generatedServices": [],
-    "services": ["installation-guide", "genesis-and-addrbook", "snapshot-service", "one-liner"]
+    "services": [
+      "installation-guide",
+      "genesis-and-addrbook",
+      "snapshot-service",
+      "one-liner"
+    ]
   },
   {
     "name": "canton-testnet",
@@ -758,7 +910,11 @@
     },
     "contributions": "Canton",
     "generatedServices": [],
-    "services": ["devnet-installation-guide", "testnet-installation-guide", "one-liner"]
+    "services": [
+      "devnet-installation-guide",
+      "testnet-installation-guide",
+      "one-liner"
+    ]
   },
   {
     "name": "canton-mainnet",
@@ -777,7 +933,10 @@
     },
     "contributions": "Canton",
     "generatedServices": [],
-    "services": ["mainnet-installation-guide", "one-liner"]
+    "services": [
+      "mainnet-installation-guide",
+      "one-liner"
+    ]
   },
   {
     "name": "monad",
@@ -796,7 +955,11 @@
     },
     "generatedServices": [],
     "contributions": "Monad",
-    "services": ["install-guide", "monitoring", "decentralize-map"]
+    "services": [
+      "install-guide",
+      "monitoring",
+      "decentralize-map"
+    ]
   },
   {
     "name": "monad-testnet",
@@ -815,7 +978,11 @@
     },
     "contributions": "Monad",
     "generatedServices": [],
-    "services": ["install-guide", "monitoring", "decentralize-map"]
+    "services": [
+      "install-guide",
+      "monitoring",
+      "decentralize-map"
+    ]
   },
   {
     "name": "near",
@@ -831,7 +998,10 @@
     "chain_id": "mainnet",
     "endpoints": {},
     "generatedServices": [],
-    "services": ["install-guide", "monitoring"]
+    "services": [
+      "install-guide",
+      "monitoring"
+    ]
   },
   {
     "name": "espresso",
@@ -846,10 +1016,13 @@
     "explorer": "",
     "endpoints": {},
     "contributions": "Espresso",
-    "generatedServices": ["installation-guide"],
-    "services": ["snapshots"]
-  }
-  ,
+    "generatedServices": [
+      "installation-guide"
+    ],
+    "services": [
+      "snapshots"
+    ]
+  },
   {
     "name": "arc-testnet",
     "type": "testnet",
@@ -864,6 +1037,8 @@
     "endpoints": {},
     "contributions": "Arc",
     "generatedServices": [],
-    "services": ["installation-guide"]
+    "services": [
+      "install-guide"
+    ]
   }
 ]


### PR DESCRIPTION
Fixed service name for Arc Network testnet installation guide.

Changed `installation-guide` → `install-guide` to match naming convention used by other networks.