### PR TITLE
feat: add MANTRA and Verona public node services

### DIFF
--- a/mantra/links.md
+++ b/mantra/links.md
@@ -1,0 +1,13 @@
+# MANTRA Chain Mainnet Links
+
+- Website: [mantrachain.io](https://mantrachain.io/)
+- Documentation: [docs.mantrachain.io](https://docs.mantrachain.io/)
+- GitHub: [MANTRA-Chain](https://github.com/MANTRA-Chain)
+- POSTHUMAN Explorer: [explorer.posthuman.digital/mantra](https://explorer.posthuman.digital/mantra)
+- POSTHUMAN Validator: [stake with POSTHUMAN](https://explorer.posthuman.digital/mantra/staking/mantravaloper1lh7g082k3v9r989s0w8hx4tp6jadqcj9wpn6uf)
+- RPC: [rpc-mantra.posthuman.digital](https://rpc-mantra.posthuman.digital/)
+- WebSocket: [wss://rpc-mantra.posthuman.digital/websocket](wss://rpc-mantra.posthuman.digital/websocket)
+- REST: [rest-mantra.posthuman.digital](https://rest-mantra.posthuman.digital/)
+- gRPC: `grpc-mantra.posthuman.digital:443`
+- Snapshots: [snapshots-mantra.posthuman.digital](https://snapshots-mantra.posthuman.digital/)
+- Genesis: [official mantra-1 genesis](https://raw.githubusercontent.com/MANTRA-Chain/net/refs/heads/main/mantra-1/genesis.json)

--- a/mantra/snapshots.md
+++ b/mantra/snapshots.md
@@ -1,0 +1,84 @@
+# Restore MANTRA Chain from a POSTHUMAN Snapshot
+
+This procedure restores a `mantra-1` node from the latest POSTHUMAN pruned
+snapshot. Download and verify the archive before stopping the node.
+
+## Prerequisites
+
+```bash
+sudo apt update
+sudo apt install -y aria2 jq lz4
+
+MANTRA_HOME="${MANTRA_HOME:-$HOME/.mantrachain}"
+SERVICE="${SERVICE:-mantrachaind}"
+SNAP_DIR="${SNAP_DIR:-$HOME/mantra-snapshot}"
+META_URL="https://snapshots-mantra.posthuman.digital/snapshot.json"
+
+mkdir -p "$SNAP_DIR" "$HOME/backups"
+```
+
+Make sure there is enough free space for both the downloaded archive and a
+temporary rollback copy of the current data directory.
+
+## Download and verify
+
+```bash
+curl -fsSL "$META_URL" -o "$SNAP_DIR/snapshot.json"
+
+SNAP_NAME=$(jq -r '.snapshot_name' "$SNAP_DIR/snapshot.json")
+SNAP_SHA256=$(jq -r '.snapshot_sha256' "$SNAP_DIR/snapshot.json")
+SNAP_URL="https://snapshots-mantra.posthuman.digital/$SNAP_NAME"
+
+aria2c --continue=true \
+  --max-connection-per-server=8 \
+  --split=8 \
+  --min-split-size=64M \
+  --file-allocation=none \
+  --dir="$SNAP_DIR" \
+  --out="$SNAP_NAME" \
+  "$SNAP_URL"
+
+printf '%s  %s\n' "$SNAP_SHA256" "$SNAP_DIR/$SNAP_NAME" | sha256sum -c -
+lz4 -t "$SNAP_DIR/$SNAP_NAME"
+```
+
+Do not continue unless both checks pass.
+
+## Stop, back up, and restore
+
+```bash
+sudo systemctl stop "$SERVICE"
+
+BACKUP_TAG=$(date -u +%Y%m%dT%H%M%SZ)
+tar -czf "$HOME/backups/mantra-keys-$BACKUP_TAG.tar.gz" \
+  -C "$MANTRA_HOME" config/priv_validator_key.json config/node_key.json \
+  keyring-file 2>/dev/null || true
+chmod 600 "$HOME/backups/mantra-keys-$BACKUP_TAG.tar.gz"
+
+cp "$MANTRA_HOME/data/priv_validator_state.json" \
+  "$HOME/backups/mantra-priv-validator-state-$BACKUP_TAG.json"
+chmod 600 "$HOME/backups/mantra-priv-validator-state-$BACKUP_TAG.json"
+
+mv "$MANTRA_HOME/data" "$MANTRA_HOME/data.rollback-$BACKUP_TAG"
+lz4 -dc "$SNAP_DIR/$SNAP_NAME" | tar -xf - -C "$MANTRA_HOME"
+
+cp "$HOME/backups/mantra-priv-validator-state-$BACKUP_TAG.json" \
+  "$MANTRA_HOME/data/priv_validator_state.json"
+```
+
+Retaining the original validator state is mandatory. Never start two nodes
+with the same consensus key.
+
+## Start and verify
+
+```bash
+sudo systemctl start "$SERVICE"
+sudo systemctl is-active "$SERVICE"
+
+curl -fsS http://127.0.0.1:26657/status | \
+  jq '.result.sync_info | {latest_block_height, catching_up}'
+```
+
+Keep the rollback directory until the restored node is synced and stable. If
+startup fails, stop the service, move the failed `data` directory aside, move
+`data.rollback-$BACKUP_TAG` back to `data`, and start the service again.

--- a/networks.json
+++ b/networks.json
@@ -1116,6 +1116,43 @@
     "chain_id": ""
   },
   {
+    "name": "mantra",
+    "type": "mainnet",
+    "title": "MANTRA Chain",
+    "website": "https://mantrachain.io/",
+    "twitter": "https://x.com/MANTRA_Chain",
+    "github": "https://github.com/MANTRA-Chain",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/refs/heads/master/mantrachain/images/OM-Prim-Col.svg",
+    "stake": "https://explorer.posthuman.digital/mantra/staking/mantravaloper1lh7g082k3v9r989s0w8hx4tp6jadqcj9wpn6uf",
+    "explorer": "https://explorer.posthuman.digital/mantra",
+    "daemon_name": "mantrachaind",
+    "chain_id": "mantra-1",
+    "codebase": {
+      "git_repo": "https://github.com/MANTRA-Chain/mantrachain",
+      "recommended_version": "v8.3.0",
+      "compatible_versions": [
+        "v8.3.0"
+      ]
+    },
+    "genesisUrl": "https://raw.githubusercontent.com/MANTRA-Chain/net/refs/heads/main/mantra-1/genesis.json",
+    "endpoints": {
+      "rpc": "https://rpc-mantra.posthuman.digital:443",
+      "rest": "https://rest-mantra.posthuman.digital:443",
+      "grpc": "https://grpc-mantra.posthuman.digital:443",
+      "peer": "4b347588da9d7c6916f902139ae019ad4edcebe0@135.181.227.236:57656",
+      "snapshots": "https://snapshots-mantra.posthuman.digital:443"
+    },
+    "contributions": "",
+    "generatedServices": [
+      "installation-guide",
+      "state-sync"
+    ],
+    "services": [
+      "snapshots",
+      "links"
+    ]
+  },
+  {
     "name": "phmn",
     "type": "mainnet",
     "title": "PHMN",

--- a/networks.json
+++ b/networks.json
@@ -1116,6 +1116,43 @@
     "chain_id": ""
   },
   {
+    "name": "verona",
+    "type": "mainnet",
+    "title": "Verona",
+    "website": "https://verona.dev/",
+    "twitter": "https://x.com/burnt_xion",
+    "github": "https://github.com/burnt-labs",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/refs/heads/master/xion/images/verona-main.svg",
+    "stake": "https://explorer.posthuman.digital/xion/staking/xionvaloper1crq50flkuw2tkahagwvddzptcdfeq45j3m6yhf",
+    "explorer": "https://explorer.posthuman.digital/xion",
+    "daemon_name": "xiond",
+    "chain_id": "xion-mainnet-1",
+    "codebase": {
+      "git_repo": "https://github.com/burnt-labs/xion",
+      "recommended_version": "v30.0.0",
+      "compatible_versions": [
+        "v30.0.0"
+      ]
+    },
+    "genesisUrl": "https://raw.githubusercontent.com/burnt-labs/burnt-networks/refs/heads/main/mainnet/xion-mainnet-1/genesis.json",
+    "endpoints": {
+      "rpc": "https://rpc-verona.posthuman.digital:443",
+      "rest": "https://rest-verona.posthuman.digital:443",
+      "grpc": "https://grpc-verona.posthuman.digital:443",
+      "peer": "c5432e01b827ba40a71320fb6a18965ab92d380d@135.181.227.236:28656",
+      "snapshots": "https://snapshots-verona.posthuman.digital:443"
+    },
+    "contributions": "",
+    "generatedServices": [
+      "installation-guide",
+      "state-sync"
+    ],
+    "services": [
+      "snapshots",
+      "links"
+    ]
+  },
+  {
     "name": "mantra",
     "type": "mainnet",
     "title": "MANTRA Chain",

--- a/verona/links.md
+++ b/verona/links.md
@@ -1,0 +1,13 @@
+# Verona Mainnet Links
+
+- Website: [verona.dev](https://verona.dev/)
+- Documentation: [docs.burnt.com/xion](https://docs.burnt.com/xion/)
+- GitHub: [burnt-labs](https://github.com/burnt-labs)
+- POSTHUMAN Explorer: [explorer.posthuman.digital/xion](https://explorer.posthuman.digital/xion)
+- POSTHUMAN Validator: [stake with POSTHUMAN](https://explorer.posthuman.digital/xion/staking/xionvaloper1crq50flkuw2tkahagwvddzptcdfeq45j3m6yhf)
+- RPC: [rpc-verona.posthuman.digital](https://rpc-verona.posthuman.digital/)
+- WebSocket: [wss://rpc-verona.posthuman.digital/websocket](wss://rpc-verona.posthuman.digital/websocket)
+- REST: [rest-verona.posthuman.digital](https://rest-verona.posthuman.digital/)
+- gRPC: `grpc-verona.posthuman.digital:443`
+- Snapshots: [snapshots-verona.posthuman.digital](https://snapshots-verona.posthuman.digital/)
+- Genesis: [official xion-mainnet-1 genesis](https://raw.githubusercontent.com/burnt-labs/burnt-networks/refs/heads/main/mainnet/xion-mainnet-1/genesis.json)

--- a/verona/snapshots.md
+++ b/verona/snapshots.md
@@ -1,0 +1,75 @@
+# Restore Verona from a POSTHUMAN Snapshot
+
+This procedure restores an `xion-mainnet-1` node from the latest POSTHUMAN
+pruned snapshot. The public network name is Verona; the technical daemon and
+home remain `xiond` and `.xiond`.
+
+Download and verify the archive before stopping the node.
+
+## Prerequisites
+
+```bash
+sudo apt update
+sudo apt install -y aria2 jq lz4
+
+XION_HOME="${XION_HOME:-$HOME/.xiond}"
+SERVICE="${SERVICE:-xiond}"
+SNAP_DIR="${SNAP_DIR:-$HOME/verona-snapshot}"
+META_URL="https://snapshots-verona.posthuman.digital/snapshot.json"
+
+mkdir -p "$SNAP_DIR" "$HOME/backups"
+```
+
+Make sure there is enough free space for both the downloaded archive and a
+temporary rollback copy of the current data directory.
+
+## Download and verify
+
+```bash
+curl -fsSL "$META_URL" -o "$SNAP_DIR/snapshot.json"
+
+SNAP_NAME=$(jq -r '.snapshot_name' "$SNAP_DIR/snapshot.json")
+SNAP_SHA256=$(jq -r '.snapshot_sha256' "$SNAP_DIR/snapshot.json")
+SNAP_URL="https://snapshots-verona.posthuman.digital/$SNAP_NAME"
+
+aria2c --continue=true   --max-connection-per-server=8   --split=8   --min-split-size=64M   --file-allocation=none   --dir="$SNAP_DIR"   --out="$SNAP_NAME"   "$SNAP_URL"
+
+printf '%s  %s\n' "$SNAP_SHA256" "$SNAP_DIR/$SNAP_NAME" | sha256sum -c -
+lz4 -t "$SNAP_DIR/$SNAP_NAME"
+```
+
+Do not continue unless both checks pass.
+
+## Stop, back up, and restore
+
+```bash
+sudo systemctl stop "$SERVICE"
+
+BACKUP_TAG=$(date -u +%Y%m%dT%H%M%SZ)
+tar -czf "$HOME/backups/verona-keys-$BACKUP_TAG.tar.gz"   -C "$XION_HOME" config/priv_validator_key.json config/node_key.json   keyring-file 2>/dev/null || true
+chmod 600 "$HOME/backups/verona-keys-$BACKUP_TAG.tar.gz"
+
+cp "$XION_HOME/data/priv_validator_state.json"   "$HOME/backups/verona-priv-validator-state-$BACKUP_TAG.json"
+chmod 600 "$HOME/backups/verona-priv-validator-state-$BACKUP_TAG.json"
+
+mv "$XION_HOME/data" "$XION_HOME/data.rollback-$BACKUP_TAG"
+lz4 -dc "$SNAP_DIR/$SNAP_NAME" | tar -xf - -C "$XION_HOME"
+
+cp "$HOME/backups/verona-priv-validator-state-$BACKUP_TAG.json"   "$XION_HOME/data/priv_validator_state.json"
+```
+
+Retaining the original validator state is mandatory. Never start two nodes
+with the same consensus key.
+
+## Start and verify
+
+```bash
+sudo systemctl start "$SERVICE"
+sudo systemctl is-active "$SERVICE"
+
+curl -fsS http://127.0.0.1:26657/status |   jq '.result.sync_info | {latest_block_height, catching_up}'
+```
+
+Keep the rollback directory until the restored node is synced and stable. If
+startup fails, stop the service, move the failed `data` directory aside, move
+`data.rollback-$BACKUP_TAG` back to `data`, and start the service again.


### PR DESCRIPTION
## Summary

- add MANTRA Chain mainnet and Verona to the public network registry
- publish POSTHUMAN RPC, REST, gRPC, P2P, snapshot, explorer, and staking links
- add download-first, checksum-verified, rollback-safe snapshot guides
- preserve Verona as the public name while retaining technical `xiond` and `xion-mainnet-1` identifiers

## Verification

### MANTRA

- public TLS, RPC, WebSocket, REST, gRPC, snapshot metadata/range, and P2P probes pass
- public RPC reports `mantra-1` with `catching_up=false`

### Verona

- backend is active/enabled with zero restarts and matches ITRocket height
- direct-origin RPC, REST, gRPC, snapshot metadata/range, and public P2P probes pass
- corrected single-label DNS records are still required before merge/deploy

### Source

- all referenced official, explorer, image, and genesis URLs return HTTP 200
- `networks.json` parses and contains unique network names
- `git diff --check` passes