### PR TITLE
fix: clarify generated installation sync guidance

### DIFF
--- a/global/installation-guide.md
+++ b/global/installation-guide.md
@@ -89,9 +89,11 @@ sudo systemctl enable {{daemon_name}}.service
 sudo systemctl start {{daemon_name}}.service
 ```
 
-### Sync node:
+### Sync the node
 
-After that you sould sync node. You have 2 ways. State-sync or download snapsot. See this guides in next tabs.
+Synchronize the node using a network-approved method. When a snapshot guide is
+available on this page, follow its preflight, backup, restore, and verification
+steps.
 
 ### Start service
 


### PR DESCRIPTION
## What changed
- replace the stale generated-guide claim that state-sync is always available in another tab
- use neutral synchronization wording that points to a verified snapshot guide when present

## Validation
- no state-sync/tab promise remains in the global installation template
- JSON parses and the diff check passes
