### PR TITLE
fix(celestia): use official Mocha release tag

### DIFF
--- a/celestia-testnet/installation-guide.md
+++ b/celestia-testnet/installation-guide.md
@@ -62,7 +62,7 @@ git clone https://github.com/celestiaorg/celestia-app.git
 cd celestia-app
 
 # Checkout current Mocha testnet version
-VERSION="v9.0.4"
+VERSION="v9.0.4-mocha"
 git checkout "tags/$VERSION"
 
 # Build and install
@@ -407,4 +407,4 @@ sed -i '/WALLET_ADDRESS_TESTNET/d' "$HOME/.bash_profile"
 
 ---
 
-**Last Updated**: v9.0.4 | Chain ID: mocha-4
+**Last Updated**: v9.0.4-mocha | Chain ID: mocha-4

--- a/celestia-testnet/one-liner.md
+++ b/celestia-testnet/one-liner.md
@@ -16,7 +16,7 @@ bash -c "$(curl -sL https://raw.githubusercontent.com/Validator-POSTHUMAN/celest
 ```
 **Current Versions:**
 - 🌐 Mainnet: `v9.0.4` (chain-id: `celestia`)
-- 🧪 Testnet: `v9.0.4` (chain-id: `mocha-4`)
+- 🧪 Testnet: `v9.0.4-mocha` (chain-id: `mocha-4`)
 - 🔧 Go: `1.26.2`
 
 ## 📋 Features

--- a/networks.json
+++ b/networks.json
@@ -540,9 +540,9 @@
     "website": "https://celestia.org/",
     "codebase": {
       "git_repo": "https://github.com/celestiaorg/celestia-app",
-      "recommended_version": "v9.0.4",
+      "recommended_version": "v9.0.4-mocha",
       "compatible_versions": [
-        "v9.0.4"
+        "v9.0.4-mocha"
       ]
     },
     "chain_name": "celestia-app",


### PR DESCRIPTION
Updates the Mocha registry and guides to the official v9.0.4-mocha tag. The tag resolves to the same verified celestia-app commit as v9.0.4. Public peer and snapshot endpoint data was also revalidated before this change.